### PR TITLE
Fix compiler warnings and errors for modern Swift

### DIFF
--- a/Sources/CLIKit/Command Line/Parser State Machine/ParserStateMachine.swift
+++ b/Sources/CLIKit/Command Line/Parser State Machine/ParserStateMachine.swift
@@ -46,7 +46,7 @@ class ParserStateMachine {
     
 }
 
-protocol ParserStateMachineDelegate: class {
+protocol ParserStateMachineDelegate: AnyObject {
     
     /// Return state to transition to from the current state given an event.
     /// Return nil to not trigger a transition.

--- a/Sources/CLIKit/Utilities/Character+Inspection.swift
+++ b/Sources/CLIKit/Utilities/Character+Inspection.swift
@@ -14,7 +14,7 @@ public extension Character {
     
     var isEmoji: Bool {
         // swiftlint:disable force_unwrapping
-        let emojiPatterns = [
+        let emojiPatterns: [ClosedRange<UnicodeScalar>] = [
             UnicodeScalar(0x1F600)!...UnicodeScalar(0x1F64F)!,
             UnicodeScalar(0x1F300)!...UnicodeScalar(0x1F5FF)!,
             UnicodeScalar(0x1F680)!...UnicodeScalar(0x1F6FF)!,


### PR DESCRIPTION
Simple fixes so that the library can be compiled with modern versions of Xcode